### PR TITLE
[85705508] Fix for displaying name in admin API

### DIFF
--- a/lib/admin-api/admin-api.js
+++ b/lib/admin-api/admin-api.js
@@ -52,7 +52,7 @@ function generateAdminRouter(conf) {
 
     //Lists all persisted backups
     api.register('backup', 'list', 'GET', function() {
-        var results = backupCollection.find({}, {_id:0, backupId:1, type:1});
+        var results = backupCollection.find({});
         return q.nbind(results.toArray, results)();
     });
 
@@ -83,6 +83,7 @@ function generateAdminRouter(conf) {
       liveBackups[id] = { 'status': 'inprogress' };
       backup.create(conf.backups.target, args.collections, args.type, args.opts)
         .then(function(backupRecord) {
+          //TODO: Should allow for multiple destinations.
           backupRecord.backupId = id;
           backupCollection.insert(backupRecord, function(e) {
             if(e) {


### PR DESCRIPTION
This is a two part change.  The admin API was not returning the name of the backup.   This commit fixes that.  The other half is in koast-admin-api.