### PR TITLE
Only log configuration details in development mode.

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,11 @@ exports.serve = function (options) {
   var log = koast.getLogger();
 
   return koast.config.whenReady
-    .then(configCli)
+    .then(function(configOptions) {
+      if ('development' === process.env.NODE_ENV) {
+        configCli(configOptions);
+      }
+    })
     .then(function () {
       // config & log now get passed in as db (koast-db-utils) is now it's own module
       return koast.db.createConfiguredConnections(null, null, koast.config,

--- a/lib/cli/templates/server/app.js
+++ b/lib/cli/templates/server/app.js
@@ -4,7 +4,9 @@ var koast = require('koast');
 
 koast.configure()
   .then(function (config) {
-    console.log('This is your configuration: ', config);
+    if ('development' === process.env.NODE_ENV) {
+      console.info('This is your configuration: ', config);
+    }
   });
 
 koast.serve();


### PR DESCRIPTION
You need to set $NODE_ENV == 'development' to see a detailed dump of your config on startup.
We should not be logging this stuff in production.